### PR TITLE
Use REST API to control the ATA

### DIFF
--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -141,22 +141,21 @@ def get_ant_pos(ant_list):
     returns dictionary with 1x3 list e.g. {'1a':[-74.7315    65.9487    0.5466]}
     """
     logger = logger_defaults.getModuleLogger(__name__)
-    stdout, stderr = ata_remote.callObs(["fxconf.rb", "antpos"])
+    antstr = snap_array_helpers.input_to_string(ant_list) 
 
-    ant_list = snap_array_helpers.input_to_list(ant_list) 
+    try:
+        endpoint = '/antennas/{:s}/locations'.format(antstr)
+        ant_locs = ATARest.get(endpoint)
+    except Exception as e:
+        logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
+        raise
 
-    retdict = {}
-    for line in stdout.splitlines():
-        if not line.startswith(b'#'):
-            sln = line.decode().split()
-            ant = sln[3]
-            pos_n = float(sln[0])
-            pos_e = float(sln[1])
-            pos_u = float(sln[2])
-            if ant in ant_list:
-                retdict[ant] = [pos_n,pos_e,pos_u]
+    retval = {}
+    for antname in ant_list:
+        loc = ant_locs[antname]
+        retval[antname] = [loc['N'], loc['E'], loc['U']]
 
-    return retdict
+    return retval
 
 def get_source_ra_dec(source, deg=True):
     """

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -381,12 +381,19 @@ def autotune(ants, power_level=-10):
     """
     assert power_level < 0, "ataautotune: power level should be negative"
     logger = logger_defaults.getModuleLogger(__name__)
+    antstr = snap_array_helpers.input_to_string(antstr)
 
-    ants = snap_array_helpers.input_to_string(ants) 
+    try:
+        logger.info("autotuning: {}".format(ants))
+        endpoint = '/antennas/{:s}/autotune'.format(antstr)
+        retval = ATARest.put(endpoint, data={'power': power_level})
+    except Exception as e:
+        logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
+        raise
 
-    logger.info("autotuning: {}".format(ants))
-    str_out,str_err = ata_remote.callObs(['ataautotune',
-        ants,'-p','%i' %power_level])
+    str_out = retval['stdout']
+    str_err = retval['stderr']
+
     #searching for warnings or errors
     rwarn = str_out.find(b"warning")
     logger.info(str_err)

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -154,20 +154,19 @@ def get_source_ra_dec(source, deg=True):
     Get the J2000 RA / DEC of `source`. Return in decimal degrees (DEC) and hours (RA)
     by default, unless `deg`=False, in which case return in sexagesimal.
     """
-    stdout, stderr = ata_remote.callObsIgnoreError(["atacheck", source])
-    ra = None
-    for lineu in stdout.decode().split("\n"):
-        line = lineu.lower()
-        if "found {}".format(source).lower() in line:
-            cols = line.split()
-            ra  = float(cols[-1].split(',')[-2])
-            dec = float(cols[-1].split(',')[-1])
-        elif "{}, was not found".format(source).lower() in line:
-            raise RuntimeError("unknown source {}".format(source))
-        elif "RA, Dec".lower() in line and not ra:
-            nums = line.split("=")[1].strip()
-            ra = float(nums.split(',')[0])
-            dec = float(nums.split(',')[1][:-1])
+
+    logger = logger_defaults.getModuleLogger(__name__)
+
+    try:
+        endpoint = '/source'
+        source_data = ATARest.get(endpoint, json={'source': source})
+    except Exception as e:
+        logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
+        raise
+
+    ra = source_data['ra']
+    dec = source_data['dec']
+
     if deg:
         return ra, dec
     else:

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -380,7 +380,7 @@ def autotune(ants, power_level=-10):
     """
     assert power_level < 0, "ataautotune: power level should be negative"
     logger = logger_defaults.getModuleLogger(__name__)
-    antstr = snap_array_helpers.input_to_string(antstr)
+    antstr = snap_array_helpers.input_to_string(ants)
 
     try:
         logger.info("autotuning: {}".format(ants))

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -394,11 +394,11 @@ def autotune(ants, power_level=-10):
     str_err = retval['stderr']
 
     #searching for warnings or errors
-    rwarn = str_out.find(b"warning")
+    rwarn = str_out.find("warning")
     logger.info(str_err)
     if rwarn != -1:
         logger.warning(str_out)
-    rerr = str_err.find(b"error")
+    rerr = str_err.find("error")
     if rerr != -1:
         logger.error(str_out)
         raise RuntimeError("Autotune execution error")

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -789,9 +789,14 @@ def release_antennas(antlist, should_park=True):
 def park_antennas(antlist):
     logger = logger_defaults.getModuleLogger(__name__)
     logger.info("Parking ants");
-    stdout, stderr = ata_remote.callObs(["park.csh", ','.join(antlist)])
-    logger.info(stdout.rstrip())
-    logger.info(stderr.rstrip())
+    antstr = snap_array_helpers.input_to_string(antlist) 
+
+    try:
+        endpoint = '/antennas/{:s}/park'.format(antstr)
+        ATARest.put(endpoint)
+    except Exception as e:
+        logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
+        raise
     logger.info("Parked");
 
 

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -306,7 +306,7 @@ def make_and_track_source(source, antstr):
         logger.info("Tracking source {:s} with {:s}".format(source, antstr))
         ephem_id = retval['id']
         endpoint = '/antennas/{:s}/track'.format(antstr)
-        ATARest.put(endpoint, json={'id': ephem_id})
+        ATARest.put(endpoint, json={'id': ephem_id, 'wait': True})
     except Exception as e:
         logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
         raise
@@ -332,7 +332,7 @@ def make_and_track_tle(tle_filename, antstr):
         ephem_id = retval['id']
         logger.info("Tracking source {:s} with {:s}".format(ephem_id, antstr))
         endpoint = '/antennas/{:s}/track'.format(antstr)
-        ATARest.put(endpoint, json={'id': ephem_id})
+        ATARest.put(endpoint, json={'id': ephem_id, 'wait': True})
     except Exception as e:
         logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
         raise
@@ -355,7 +355,7 @@ def make_and_track_ra_dec(ra, dec, antstr):
 
         ephem_id = retval['id']
         endpoint = '/antennas/{:s}/track'.format(antstr)
-        ATARest.put(endpoint, json={'id': ephem_id})
+        ATARest.put(endpoint, json={'id': ephem_id, 'wait': True})
     except Exception as e:
         logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
         raise
@@ -394,11 +394,11 @@ def autotune(ants, power_level=-10):
     str_err = retval['stderr']
 
     #searching for warnings or errors
-    rwarn = str_out.find("warning")
+    rwarn = str_out.find("WARNING")
     logger.info(str_err)
     if rwarn != -1:
         logger.warning(str_out)
-    rerr = str_err.find("error")
+    rerr = str_err.find("ERROR")
     if rerr != -1:
         logger.error(str_out)
         raise RuntimeError("Autotune execution error")
@@ -1129,7 +1129,7 @@ def point_ants2(source, on_or_off, ant_list):
     # with the _on or _off suffix
 
     source_name = '{:s}_{:s}'.format(source, on_or_off)
-    track_json_payload = {'id': source, 'name': source_name}
+    track_json_payload = {'id': source, 'name': source_name, 'wait': True}
 
     # If off source pointing is requested, alter the track at runtime
     # by the previously stored az/el offset

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -255,7 +255,7 @@ def set_az_el(ant_list, az, el):
 
     try:
         endpoint = '/antennas/{:s}/azel'.format(antstr)
-        antpos = ATARest.put(endpoint, data={'az': az, 'el': el})
+        antpos = ATARest.put(endpoint, data={'az': az, 'el': el, 'wait': True})
     except Exception as e:
         logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
         raise
@@ -809,7 +809,7 @@ def park_antennas(antlist):
 
     try:
         endpoint = '/antennas/{:s}/park'.format(antstr)
-        ATARest.put(endpoint)
+        ATARest.put(endpoint, data={'wait': True})
     except Exception as e:
         logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
         raise

--- a/pythonLibs/ATATools/ata_control.py
+++ b/pythonLibs/ATATools/ata_control.py
@@ -40,8 +40,16 @@ def get_ascii_status():
     there __MAY__ be white space separation within a column)
     """
     
-    stdout, stderr = ata_remote.callObs(["ataasciistatus","-l"])
-    return stdout
+    logger = logger_defaults.getModuleLogger(__name__)
+
+    try:
+        endpoint = '/status'
+        response = ATARest.get(endpoint)
+        return response['status']
+    except Exception as e:
+        logger.error('{:s} got error: {:s}'.format(endpoint, str(e)))
+        raise
+
 
 #####
 #

--- a/pythonLibs/ATATools/ata_rest.py
+++ b/pythonLibs/ATATools/ata_rest.py
@@ -1,0 +1,126 @@
+import requests
+
+
+class ATARestException(Exception):
+    """
+    Base exception for any ATA REST related problems
+    """
+    pass
+
+
+class ATARest:
+    """
+    Simple API to encapsulate REST calls with more directed error handling.
+    Any errors will cause a ATARestException to be thrown with any error message
+    if available.
+    """
+    
+    HOST = 'restgw.hcro.org'
+    PORT = 12345
+
+    RETURN_MSG_KEY = 'message'
+
+    _OP_GET = 'get'
+    _OP_PUT = 'put'
+    _OP_DEL = 'delete'
+
+    _debug = False
+
+    @classmethod
+    def form_url(cls, endpoint):
+        if not endpoint.startswith('/'):
+            endpoint = '/' + endpoint
+        url = 'http://{:s}:{:d}{:s}'.format(cls.HOST, cls.PORT, endpoint)
+        return url
+
+    @classmethod
+    def _do_op(cls, op, endpoint, **kwargs):
+        """
+        Handle one of the HTTP operations
+
+        :param op: HTTP operation to perform
+        :param endpoint: REST endpoint (no stem) to call
+        :param kwargs: any additional arguments to requests.get(), etc.
+        
+        :returns dict from JSON section of REST server response
+        :rtype dict
+
+        :raises ATARestException on any error response
+        """
+
+        try:
+            url = cls.form_url(endpoint)
+            if cls._debug:
+                print(url)
+
+            if op == cls._OP_GET:
+                response = requests.get(url, **kwargs)
+            elif op == cls._OP_PUT:
+                response = requests.put(url, **kwargs)
+            elif op == cls._OP_DEL:
+                response = requests.delete(url, **kwargs)
+            else:
+                raise ATARestException('Bad op given to ATARest._do_op()')
+
+            json = response.json()
+            if response.status_code != requests.codes.ok:
+                if json and cls.RETURN_MSG_KEY in json:
+                    raise ATARestException(json[cls.RETURN_MSG_KEY])
+                else:
+                    raise ATARestException('No error message from REST API ' + op)
+            if cls._debug:
+                print(json)
+            return json
+        except Exception as e:
+            raise ATARestException(str(e))
+
+
+    @classmethod
+    def get(cls, endpoint, **kwargs):
+        """
+        HTTP GET operation on ATA REST API endpoint
+
+        :param endpoint: REST endpoint (no stem) to call
+        :param kwargs: any additional arguments to requests.get(), etc.
+
+        :returns dict from JSON section of REST server response
+        :rtype dict
+
+        :raises ATARestException on any error response
+        """
+        return cls._do_op(cls._OP_GET, endpoint, **kwargs)
+
+    @classmethod
+    def put(cls, endpoint, **kwargs):
+        """
+        HTTP PUT operation on ATA REST API endpoint
+
+        :param endpoint: REST endpoint (no stem) to call
+        :param kwargs: any additional arguments to requests.get(), etc.
+
+        :returns dict from JSON section of REST server response
+        :rtype dict
+
+        :raises ATARestException on any error response
+        """
+        return cls._do_op(cls._OP_PUT, endpoint, **kwargs)
+
+    @classmethod
+    def delete(cls, endpoint, **kwargs):
+        """
+        HTTP DELETE operation on ATA REST API endpoint
+
+        :param endpoint: REST endpoint (no stem) to call
+        :param kwargs: any additional arguments to requests.get(), etc.
+
+        :returns dict from JSON section of REST server response
+        :rtype dict
+
+        :raises ATARestException on any error response
+        """
+        return cls._do_op(cls._OP_DEL, endpoint, **kwargs)
+    
+
+if __name__ == '__main__':
+    print(ATARest.get('/antennas/1a/pams'))
+

--- a/pythonLibs/ATATools/ata_rest.py
+++ b/pythonLibs/ATATools/ata_rest.py
@@ -22,6 +22,7 @@ class ATARest:
 
     _OP_GET = 'get'
     _OP_PUT = 'put'
+    _OP_POST = 'post'
     _OP_DEL = 'delete'
 
     _debug = False
@@ -59,6 +60,8 @@ class ATARest:
                 response = requests.put(url, **kwargs)
             elif op == cls._OP_DEL:
                 response = requests.delete(url, **kwargs)
+            elif op == cls._OP_POST:
+                response = requests.post(url, **kwargs)
             else:
                 raise ATARestException('Bad op given to ATARest._do_op()')
 
@@ -104,6 +107,21 @@ class ATARest:
         :raises ATARestException on any error response
         """
         return cls._do_op(cls._OP_PUT, endpoint, **kwargs)
+
+    @classmethod
+    def post(cls, endpoint, **kwargs):
+        """
+        HTTP POST operation on ATA REST API endpoint
+
+        :param endpoint: REST endpoint (no stem) to call
+        :param kwargs: any additional arguments to requests.get(), etc.
+
+        :returns dict from JSON section of REST server response
+        :rtype dict
+
+        :raises ATARestException on any error response
+        """
+        return cls._do_op(cls._OP_POST, endpoint, **kwargs)
 
     @classmethod
     def delete(cls, endpoint, **kwargs):


### PR DESCRIPTION
Merge the `ata-rest` branch developed by @tkoumrian: replace the ssh-based commands with the REST API calls to perform the various control functions.
The function calls have the same signature and in principle, end-users should not notice any differences, nor perform any changes from their end. 