### PR TITLE
Fix amplitude command units

### DIFF
--- a/SignalGenerator/srs_sg384_control.py
+++ b/SignalGenerator/srs_sg384_control.py
@@ -64,7 +64,7 @@ def set_amp(amp):
     telnet = telnetlib.Telnet()
     telnet.open(_host, _port)
 
-    telnet.write("AMPR {} MHz\n".format(amp))
+    telnet.write("AMPR {} Dbm\n".format(amp))
 
 def get_clock_settings():
 


### PR DESCRIPTION
A copy-paste error means the amplitude command was using units of MHz, which meant the command failed silently. This was tested by running the command and then reading back with the `-p` flag.