### PR TITLE
*^ SNAPObs/snap_hpguppi/meta_marshall

### DIFF
--- a/pythonLibs/SNAPobs/snap_hpguppi/scripts/meta_marshall.py
+++ b/pythonLibs/SNAPobs/snap_hpguppi/scripts/meta_marshall.py
@@ -121,6 +121,8 @@ def read_chan_dest_ips(feng, interface, ignore_null_packets=True):
 
   try:
     if isinstance(feng, ata_rfsoc_fengine.AtaRfsocFengine):
+      feng._read_parameters_from_fpga()
+      feng._calc_output_ids()
       feng_headers = feng._read_headers()
     else:
       feng_headers = feng._read_headers(interface)


### PR DESCRIPTION
- read-params from fpga if RFSoC before reading headers
- accounts for changes in n_interfaces (4bit=1, 8bit=2)


Preferably before #21 